### PR TITLE
Fix delay()

### DIFF
--- a/avr/cores/microcore/wiring.c
+++ b/avr/cores/microcore/wiring.c
@@ -117,9 +117,8 @@ uint32_t micros()
 // Wrapper to deal with _delay_ms(), which is an inline function
 void delay(uint16_t ms)
 {
-  do
+  while(ms--)
     _delay_ms(1);
-  while(--ms);
 }
 
 


### PR DESCRIPTION
Calling delay(0) would unexpectedly block for a while. This fixes the issue.